### PR TITLE
Fix crash on 5.14+

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -153,7 +153,7 @@ led_marquee.set_timer = function(pos, timeout)
 end
 
 led_marquee.scroll_text = function(pos, elapsed, skip)
-	skip = skip or 1
+	if type(skip) ~= "number" then skip = 1 end
 	local meta = minetest.get_meta(pos)
 	local msg = meta:get_string("last_msg")
 	local channel = meta:get_string("channel")


### PR DESCRIPTION
5.14 supplies extra arguments when calling `on_timer` functions, including a third argument in the form of a table. This was causing a crash in `led_marquee.scroll_text()`:
```
2025-09-20 14:03:55: ERROR[Main]: ServerError: AsyncErr: Lua: Runtime error from mod 'led_marquee' in callback node_on_timer(): ...netest/games/dreambuilder_game/mods/led_marquee/init.lua:165: attempt to perform arithmetic on local 'skip' (a table value)
2025-09-20 14:03:55: ERROR[Main]: stack traceback:
2025-09-20 14:03:55: ERROR[Main]: 	...netest/games/dreambuilder_game/mods/led_marquee/init.lua:165: in function <...netest/games/dreambuilder_game/mods/led_marquee/init.lua:155>
```

This PR just changes the `skip` value check to look for an actual number instead of just the presence of the argument at all.